### PR TITLE
Update Fedora38-11thGen.md - Fix typo:  "walyland" -> "wayland"

### DIFF
--- a/Fedora38-11thGen.md
+++ b/Fedora38-11thGen.md
@@ -11,7 +11,7 @@
 ### Make sure to update your packages first
 ``sudo dnf upgrade``
 
-### If you want to enable fractional scaling on Walyland:
+### If you want to enable fractional scaling on Wayland:
 ``
 gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']"
 


### PR DESCRIPTION
Fix typo:  "walyland" -> "wayland"