### PR TITLE
Update Fedora39-12thGen.md

### DIFF
--- a/Fedora39-12thGen.md
+++ b/Fedora39-12thGen.md
@@ -49,6 +49,9 @@ gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffe
 ```
 > **TIP:** You can use the little clipboard icon to the right of the code to copy to your clipboard.
 
+
+**Reboot**
+
 &nbsp;
 &nbsp;
 &nbsp;


### PR DESCRIPTION
Adjust language to mention reboot, as it was required for my setup yesterday.

It also appears that the arch linux wiki has a similar recommendation.
> then open Settings > Devices > Displays (the new options may only appear after a restart). 
https://wiki.archlinux.org/title/HiDPI#Wayland