### PR TITLE
Only update /etc/default/grub in OEM kernel update instructions if 'quiet splash' are not included

### DIFF
--- a/22.04-OEM-C.md
+++ b/22.04-OEM-C.md
@@ -10,6 +10,6 @@
 ```
 latest_oem_kernel=$(ls /boot/vmlinuz-* | awk -F"-" '{split($0, a, "-"); version=a[3]; if (version>max) {max=version; kernel=a[2] "-" a[3] "-" a[4]}} END{print kernel}')
 sudo sed -i.bak '/^GRUB_DEFAULT=/c\GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux '"$latest_oem_kernel"'"' /etc/default/grub
-sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"/g' /etc/default/grub
+sudo sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT.*quiet splash/!s/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"/' /etc/default/grub
 sudo update-grub
 ```


### PR DESCRIPTION
Don't update this line if quiet splash is present. 

Fixes https://community.frame.work/t/amd-oem-kernel-update-procedure-breaks-hibernate-by-updating-grub-cmdline-linux-default-in-etc-default-grub/44726

This:
1. Checks if `quiet splash` is included on the defaults line
2. Only blitzes the line if they are not present
3. Leaves the line as-is if quiet splash are present.

Why?

- If a user has enabled hibernation, this will not remove their hibernate configs from this line and break hibernation (so long as they have quiet splash)

Improvements?
It might be good to be more sophisticated with this check and warn users if something will be overwritten. 