### PR TITLE
Ubuntu/Mint: Disable ALS through modprobe.d

### DIFF
--- a/LinuxMint21-1-Manual-Setup-12thGen.md
+++ b/LinuxMint21-1-Manual-Setup-12thGen.md
@@ -6,7 +6,7 @@
 - Update your Linux Mint install's packages.
 - Install the recommended OEM kernel. Now recommending a new OEM kernel.
 - Workaround needed to get the best suspend battery life for SSD power drain.
-- Disable the ALS sensor so that your brightness keys work.
+- Disable the Ambient Light Sensor so that your brightness keys work.
 - Enable headset mic input.
 
 ##  *****COPY AND PASTE THIS CODE BELOW INTO A TERMINAL*****
@@ -19,7 +19,7 @@
 
 
 ``
-sudo apt update && sudo apt upgrade -y && sudo apt-get install linux-oem-22.04c -y && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
+sudo apt update && sudo apt upgrade -y && sudo apt-get install linux-oem-22.04c -y && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
 ``
 
 ## *****COPY AND PASTE THIS CODE ABOVE INTO A TERMINAL*****
@@ -45,16 +45,8 @@ If you would rather enter the commands individually **instead** of using the cod
 ### Enable headset mic input.
 ``echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf``
 
-### Disable the ALS sensor so that your brightness keys work, 13th gen only.
-``sudo gedit /etc/default/grub``
-
-### Append the following to the GRUB_CMDLINE_LINUX_DEFAULT="quiet splash section.
-``
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub"
-``
-
-### Then run
-``sudo update-grub``
+### Disable the Ambient Light Sensor so that your brightness keys work, 13th gen only.
+``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
 
 ### Workaround needed to get the best suspend battery life for SSD power drain.
 ``sudo gedit /etc/default/grub``

--- a/LinuxMint21-1-Manual-Setup-12thGen.md
+++ b/LinuxMint21-1-Manual-Setup-12thGen.md
@@ -19,7 +19,7 @@
 
 
 ``
-sudo apt update && sudo apt upgrade -y && sudo apt-get install linux-oem-22.04c -y && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
+echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && sudo apt update && sudo apt upgrade -y && sudo apt-get install linux-oem-22.04c -y && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
 ``
 
 ## *****COPY AND PASTE THIS CODE ABOVE INTO A TERMINAL*****
@@ -47,6 +47,9 @@ If you would rather enter the commands individually **instead** of using the cod
 
 ### Disable the Ambient Light Sensor so that your brightness keys work, 13th gen only.
 ``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
+
+Update the initramfs:
+``sudo update-initramfs -u``
 
 ### Workaround needed to get the best suspend battery life for SSD power drain.
 ``sudo gedit /etc/default/grub``

--- a/LinuxMint21-1-Manual-Setup-13thGen.md
+++ b/LinuxMint21-1-Manual-Setup-13thGen.md
@@ -6,7 +6,7 @@
 - Update your Linux Mint install's packages.
 - Install the recommended OEM kernel. Now recommending a new OEM kernel.
 - Workaround needed to get the best suspend battery life for SSD power drain.
-- Disable the ALS sensor so that your brightness keys work.
+- Disable the Ambient Light Sensor so that your brightness keys work.
 - Enable headset mic input.
 
 ##  *****COPY AND PASTE THIS CODE BELOW INTO A TERMINAL*****
@@ -19,7 +19,7 @@
 
 
 ``
-sudo apt update && sudo apt upgrade -y && sudo apt-get install linux-oem-22.04c -y && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
+sudo apt update && sudo apt upgrade -y && sudo apt-get install linux-oem-22.04c -y && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
 ``
 
 ## *****COPY AND PASTE THIS CODE ABOVE INTO A TERMINAL*****
@@ -45,18 +45,8 @@ If you would rather enter the commands individually **instead** of using the cod
 ### Enable headset mic input.
 ``echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf``
 
-### Disable the ALS sensor so that your brightness keys work, 13th gen only.
-``sudo gedit /etc/default/grub``
-
-### Append the following to the GRUB_CMDLINE_LINUX_DEFAULT="quiet splash section.
-This will address your brightness keys.
-
-``
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub"
-``
-
-### Then run
-``sudo update-grub``
+### Disable the Ambient Light Sensor so that your brightness keys work, 13th gen only.
+``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
 
 ### Workaround needed to get the best suspend battery life for SSD power drain.
 ``sudo gedit /etc/default/grub``

--- a/LinuxMint21-1-Manual-Setup-13thGen.md
+++ b/LinuxMint21-1-Manual-Setup-13thGen.md
@@ -19,7 +19,7 @@
 
 
 ``
-sudo apt update && sudo apt upgrade -y && sudo apt-get install linux-oem-22.04c -y && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
+echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && sudo apt update && sudo apt upgrade -y && sudo apt-get install linux-oem-22.04c -y && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
 ``
 
 ## *****COPY AND PASTE THIS CODE ABOVE INTO A TERMINAL*****
@@ -47,6 +47,9 @@ If you would rather enter the commands individually **instead** of using the cod
 
 ### Disable the Ambient Light Sensor so that your brightness keys work, 13th gen only.
 ``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
+
+Update the initramfs:
+``sudo update-initramfs -u``
 
 ### Workaround needed to get the best suspend battery life for SSD power drain.
 ``sudo gedit /etc/default/grub``

--- a/Ubuntu22.04LTS-Manual-Setup-12thGen.md
+++ b/Ubuntu22.04LTS-Manual-Setup-12thGen.md
@@ -4,8 +4,8 @@
 ## This will:
 
 - Update your Ubuntu install's packages.
-- Install the recommended OEM kernel and provide you with an alert should the OEM kernel needing updating.
 - Disable the Ambient Light Sensor so that your brightness keys work.
+- Install the recommended OEM kernel and provide you with an alert should the OEM kernel needing updating.
 
 &nbsp; &nbsp; &nbsp; &nbsp; 
 
@@ -18,8 +18,8 @@
 - Then press the enter key, user password, enter key, **reboot.**
 
 ```
-sudo apt update && sudo apt upgrade -y && sudo snap refresh && sudo apt-get install linux-oem-22.04c -y
 echo 'blacklist hid_sensor_hub' | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf
+sudo apt update && sudo apt upgrade -y && sudo snap refresh && sudo apt-get install linux-oem-22.04c -y
 ```
 > **TIP:** You can use the little clipboard icon to the right of the code to copy to your clipboard.
 
@@ -74,13 +74,16 @@ If you would rather enter the commands individually **instead** of using the cod
 ### Step 1 (ADVANCED USERS) Updating packages.
 ``sudo apt update && sudo apt upgrade -y``
 
-### Step 2 (ADVANCED USERS) Install the recommended OEM kernel.
+### Step 2 (ADVANCED USERS) Disable the Ambient Light Sensor so that your brightness keys work.
+``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
+
+To update the module list in the existing kernel image:
+``sudo update-initramfs -u``
+
+### Step 3 (ADVANCED USERS) Install the recommended OEM kernel.
 ``sudo apt install linux-oem-22.04c``
 
 **Reboot**
-
-### Step 3 (ADVANCED USERS) Disable the Ambient Light Sensor so that your brightness keys work.
-``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
 
 ### Step 4 (ADVANCED USERS) Indentify your OEM C kernel.
 

--- a/Ubuntu22.04LTS-Manual-Setup-12thGen.md
+++ b/Ubuntu22.04LTS-Manual-Setup-12thGen.md
@@ -5,7 +5,7 @@
 
 - Update your Ubuntu install's packages.
 - Install the recommended OEM kernel and provide you with an alert should the OEM kernel needing updating.
-- Disable the ALS sensor so that your brightness keys work.
+- Disable the Ambient Light Sensor so that your brightness keys work.
 
 &nbsp; &nbsp; &nbsp; &nbsp; 
 
@@ -19,6 +19,7 @@
 
 ```
 sudo apt update && sudo apt upgrade -y && sudo snap refresh && sudo apt-get install linux-oem-22.04c -y
+echo 'blacklist hid_sensor_hub' | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf
 ```
 > **TIP:** You can use the little clipboard icon to the right of the code to copy to your clipboard.
 
@@ -35,7 +36,6 @@ sudo apt update && sudo apt upgrade -y && sudo snap refresh && sudo apt-get inst
 ```
 latest_oem_kernel=$(ls /boot/vmlinuz-* | awk -F"-" '{split($0, a, "-"); version=a[3]; if (version>max) {max=version; kernel=a[2] "-" a[3] "-" a[4]}} END{print kernel}')
 sudo sed -i.bak '/^GRUB_DEFAULT=/c\GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux '"$latest_oem_kernel"'"' /etc/default/grub
-sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub"/g' /etc/default/grub
 sudo update-grub && sudo apt install zenity && mkdir -p ~/.config/autostart && [ ! -f ~/.config/autostart/kernel_check.desktop ] && echo -e "[Desktop Entry]\nType=Application\nExec=bash -c \"latest_oem_kernel=\$(ls /boot/vmlinuz-* | grep '6.1.0-10..-oem' | sort -V | tail -n1 | awk -F'/' '{print \\\$NF}' | sed 's/vmlinuz-//') && current_grub_kernel=\$(grep '^GRUB_DEFAULT=' /etc/default/grub | sed -e 's/GRUB_DEFAULT=\\\"Advanced options for Ubuntu>Ubuntu, with Linux //g' -e 's/\\\"//g') && [ \\\"\\\${latest_oem_kernel}\\\" != \\\"\\\${current_grub_kernel}\\\" ] && zenity --text-info --html --width=300 --height=200 --title=\\\"Kernel Update Notification\\\" --filename=<(echo -e \\\"A newer OEM C kernel is available than what is set in GRUB. <a href='https://github.com/FrameworkComputer/linux-docs/blob/main/22.04-OEM-C.md'>Click here</a> to learn more.\\\")\"\nHidden=false\nNoDisplay=false\nX-GNOME-Autostart-enabled=true\nName[en_US]=Kernel check\nName=Kernel check\nComment[en_US]=\nComment=" > ~/.config/autostart/kernel_check.desktop
 ```
 
@@ -45,7 +45,6 @@ sudo update-grub && sudo apt install zenity && mkdir -p ~/.config/autostart && [
 
 &nbsp; &nbsp; &nbsp; &nbsp; 
 ## What the above code does.
-- Disables the ALS sensor so that your brightness keys work.
 - Ensures GRUB is using the latest OEM C kernel at every boot.
 - Creates a desktop file as an autostart to check for OEM kernel status.
 - If an update comes about for the OEM kernel, is installed, but GRUB still has the older version - an alert box will provide you with a link to get this corrected.
@@ -80,12 +79,8 @@ If you would rather enter the commands individually **instead** of using the cod
 
 **Reboot**
 
-### Step 3 (ADVANCED USERS) Disable the ALS sensor so that your brightness keys work.
-``sudo gedit /etc/default/grub``
-
-Add module_blacklist=hid_sensor_hub so it looks like:
-
-``GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub"``
+### Step 3 (ADVANCED USERS) Disable the Ambient Light Sensor so that your brightness keys work.
+``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
 
 ### Step 4 (ADVANCED USERS) Indentify your OEM C kernel.
 

--- a/Ubuntu22.04LTS-Manual-Setup-13thGen.md
+++ b/Ubuntu22.04LTS-Manual-Setup-13thGen.md
@@ -17,8 +17,7 @@
 - Then press the enter key, user password, enter key, **reboot.**
 
 ```
-sudo apt update && sudo apt upgrade -y && sudo snap refresh && sudo apt-get install linux-oem-22.04c -y
-echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf
+echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && sudo apt update && sudo apt upgrade -y && sudo snap refresh && sudo apt-get install linux-oem-22.04c -y
 ```
 
 > **TIP:** You can use the little clipboard icon to the right of the code to copy to your clipboard.
@@ -79,11 +78,14 @@ If you would rather enter the commands individually **instead** of using the cod
 ### Step 1 (ADVANCED USERS) Updating packages.
 ``sudo apt update && sudo apt upgrade -y``
 
-### Step 2 (ADVANCED USERS) Install the recommended OEM kernel.
-``sudo apt install linux-oem-22.04c``
-
-### Step 3 (ADVANCED USERS) Disable the Ambient Light Sensor so that your brightness keys work.
+### Step 2 (ADVANCED USERS) Disable the Ambient Light Sensor so that your brightness keys work.
 ``echo 'blacklist hid_sensor_hub' | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
+
+To update the current kernel initramfs:
+``sudo update-initramfs -u``
+
+### Step 3 (ADVANCED USERS) Install the recommended OEM kernel.
+``sudo apt install linux-oem-22.04c``
 
 **Reboot**
 

--- a/Ubuntu22.04LTS-Manual-Setup-13thGen.md
+++ b/Ubuntu22.04LTS-Manual-Setup-13thGen.md
@@ -4,7 +4,7 @@
 
 - Update your Ubuntu install's packages.
 - Install the recommended OEM kernel and provide you with an alert should the OEM kernel needing updating.
-- Disable the ALS sensor so that your brightness keys work.
+- Disable the Ambient Light Sensor so that your brightness keys work.
 
 &nbsp; &nbsp; &nbsp; &nbsp; 
 
@@ -18,6 +18,7 @@
 
 ```
 sudo apt update && sudo apt upgrade -y && sudo snap refresh && sudo apt-get install linux-oem-22.04c -y
+echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf
 ```
 
 > **TIP:** You can use the little clipboard icon to the right of the code to copy to your clipboard.
@@ -39,7 +40,6 @@ sudo apt update && sudo apt upgrade -y && sudo snap refresh && sudo apt-get inst
 ```
 latest_oem_kernel=$(ls /boot/vmlinuz-* | awk -F"-" '{split($0, a, "-"); version=a[3]; if (version>max) {max=version; kernel=a[2] "-" a[3] "-" a[4]}} END{print kernel}')
 sudo sed -i.bak '/^GRUB_DEFAULT=/c\GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux '"$latest_oem_kernel"'"' /etc/default/grub
-sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub"/g' /etc/default/grub
 sudo update-grub && sudo apt install zenity && mkdir -p ~/.config/autostart && [ ! -f ~/.config/autostart/kernel_check.desktop ] && echo -e "[Desktop Entry]\nType=Application\nExec=bash -c \"latest_oem_kernel=\$(ls /boot/vmlinuz-* | grep '6.1.0-10..-oem' | sort -V | tail -n1 | awk -F'/' '{print \\\$NF}' | sed 's/vmlinuz-//') && current_grub_kernel=\$(grep '^GRUB_DEFAULT=' /etc/default/grub | sed -e 's/GRUB_DEFAULT=\\\"Advanced options for Ubuntu>Ubuntu, with Linux //g' -e 's/\\\"//g') && [ \\\"\\\${latest_oem_kernel}\\\" != \\\"\\\${current_grub_kernel}\\\" ] && zenity --text-info --html --width=300 --height=200 --title=\\\"Kernel Update Notification\\\" --filename=<(echo -e \\\"A newer OEM C kernel is available than what is set in GRUB. <a href='https://github.com/FrameworkComputer/linux-docs/blob/main/22.04-OEM-C.md'>Click here</a> to learn more.\\\")\"\nHidden=false\nNoDisplay=false\nX-GNOME-Autostart-enabled=true\nName[en_US]=Kernel check\nName=Kernel check\nComment[en_US]=\nComment=" > ~/.config/autostart/kernel_check.desktop
 ```
 > **TIP:** You can use the little clipboard icon to the right of the code to copy to your clipboard.
@@ -50,7 +50,6 @@ sudo update-grub && sudo apt install zenity && mkdir -p ~/.config/autostart && [
 
 
 ## What the above code does.
-- Disables the ALS sensor so that your brightness keys work.
 - Ensures GRUB is using the latest OEM C kernel at every boot.
 - Creates a desktop file as an autostart to check for OEM kernel status.
 - If an update comes about for the OEM kernel, is installed, but GRUB still has the older version - an alert box will provide you with a link to get this corrected.
@@ -83,14 +82,10 @@ If you would rather enter the commands individually **instead** of using the cod
 ### Step 2 (ADVANCED USERS) Install the recommended OEM kernel.
 ``sudo apt install linux-oem-22.04c``
 
+### Step 3 (ADVANCED USERS) Disable the Ambient Light Sensor so that your brightness keys work.
+``echo 'blacklist hid_sensor_hub' | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
+
 **Reboot**
-
-### Step 3 (ADVANCED USERS) Disable the ALS sensor so that your brightness keys work.
-``sudo gedit /etc/default/grub``
-
-Add module_blacklist=hid_sensor_hub so it looks like:
-
-``GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub"``
 
 ### Step 4 (ADVANCED USERS) Indentify your OEM C kernel.
 

--- a/Ubuntu23.04-Manual-Setup-11thGen.md
+++ b/Ubuntu23.04-Manual-Setup-11thGen.md
@@ -54,8 +54,11 @@ gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffe
 echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-framework-light-sensor.conf
 ``
 
-### Then run
-``sudo update-grub``
+Update the initramfs:
+
+``
+sudo update-initramfs -u
+``
 
 ### Workaround needed to get the best suspend battery life for SSD power drain.
 ``sudo gnome-text-editor /etc/default/grub``

--- a/Ubuntu23.04-Manual-Setup-11thGen.md
+++ b/Ubuntu23.04-Manual-Setup-11thGen.md
@@ -49,9 +49,9 @@ If you would rather enter the commands individually **instead** of using the cod
 gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']"
 ``
 
-### Append the following to the GRUB_CMDLINE_LINUX_DEFAULT="quiet splash section.
+### Disable Ambient Light Sensor to fix brightness keys
 ``
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub"
+echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-framework-light-sensor.conf
 ``
 
 ### Then run

--- a/Ubuntu23.04-Manual-Setup-12thGen.md
+++ b/Ubuntu23.04-Manual-Setup-12thGen.md
@@ -22,7 +22,7 @@
 
 
 ``
-sudo apt update && sudo apt upgrade -y && sudo snap refresh && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']" && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
+sudo apt update && sudo apt upgrade -y && sudo snap refresh && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && sudo update-initramfs -u && gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']" && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
 ``
 
 ## *****COPY AND PASTE THIS CODE ABOVE INTO A TERMINAL*****
@@ -52,6 +52,9 @@ gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffe
 
 ### Disable the Ambient Light Sensor so that your brightness keys work, 12th gen only.
 ``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
+
+Update the initramfs:
+``sudo update-initramfs -u``
 
 ### Workaround needed to get the best suspend battery life for SSD power drain.
 ``sudo gnome-text-editor /etc/default/grub``

--- a/Ubuntu23.04-Manual-Setup-12thGen.md
+++ b/Ubuntu23.04-Manual-Setup-12thGen.md
@@ -5,7 +5,7 @@
 
 - Update your Ubuntu install's packages.
 - Workaround needed to get the best suspend battery life for SSD power drain.
-- Disable the ALS sensor so that your brightness keys work.
+- Disable the Ambient Light Sensor so that your brightness keys work.
 - Enable improved fractional scaling support for Ubuntu's GNOME environment using Wayland.
 - Enable headset mic input.
 
@@ -22,7 +22,7 @@
 
 
 ``
-sudo apt update && sudo apt upgrade -y && sudo snap refresh && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']" && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
+sudo apt update && sudo apt upgrade -y && sudo snap refresh && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']" && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
 ``
 
 ## *****COPY AND PASTE THIS CODE ABOVE INTO A TERMINAL*****
@@ -50,16 +50,8 @@ If you would rather enter the commands individually **instead** of using the cod
 gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']"
 ``
 
-### Disable the ALS sensor so that your brightness keys work, 12th gen only.
-``sudo gnome-text-editor /etc/default/grub``
-
-### Append the following to the GRUB_CMDLINE_LINUX_DEFAULT="quiet splash section.
-``
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub"
-``
-
-### Then run
-``sudo update-grub``
+### Disable the Ambient Light Sensor so that your brightness keys work, 12th gen only.
+``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
 
 ### Workaround needed to get the best suspend battery life for SSD power drain.
 ``sudo gnome-text-editor /etc/default/grub``

--- a/Ubuntu23.04-Manual-Setup-13thGen.md
+++ b/Ubuntu23.04-Manual-Setup-13thGen.md
@@ -22,7 +22,7 @@
 
 
 ``
-sudo apt update && sudo apt upgrade -y && sudo snap refresh && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']" && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
+echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && sudo apt update && sudo apt upgrade -y && sudo snap refresh && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']" && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
 ``
 
 ## *****COPY AND PASTE THIS CODE ABOVE INTO A TERMINAL*****
@@ -52,6 +52,9 @@ gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffe
 
 ### Disable the Ambient Light Sensor so that your brightness keys work, 13th gen only.
 ``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
+
+Update the initramfs:
+``sudo update-initramfs -u``
 
 ### Workaround needed to get the best suspend battery life for SSD power drain.
 ``sudo gnome-text-editor /etc/default/grub``

--- a/Ubuntu23.04-Manual-Setup-13thGen.md
+++ b/Ubuntu23.04-Manual-Setup-13thGen.md
@@ -5,7 +5,7 @@
 
 - Update your Ubuntu install's packages.
 - Workaround needed to get the best suspend battery life for SSD power drain.
-- Disable the ALS sensor so that your brightness keys work.
+- Disable the Ambient Light sensor so that your brightness keys work.
 - Enable improved fractional scaling support for Ubuntu's GNOME environment using Wayland.
 - Enable headset mic input.
 
@@ -22,7 +22,7 @@
 
 
 ``
-sudo apt update && sudo apt upgrade -y && sudo snap refresh && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']" && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
+sudo apt update && sudo apt upgrade -y && sudo snap refresh && echo "options snd-hda-intel model=dell-headset-multi" | sudo tee -a /etc/modprobe.d/alsa-base.conf && echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf && gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']" && sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvme.noacpi=1"/g' /etc/default/grub && sudo update-grub && echo "[connection]" | sudo tee /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf && echo "wifi.powersave = 2" | sudo tee -a /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
 ``
 
 ## *****COPY AND PASTE THIS CODE ABOVE INTO A TERMINAL*****
@@ -50,16 +50,8 @@ If you would rather enter the commands individually **instead** of using the cod
 gsettings set org.gnome.mutter experimental-features "['scale-monitor-framebuffer']"
 ``
 
-### Disable the ALS sensor so that your brightness keys work, 13th gen only.
-``sudo gnome-text-editor /etc/default/grub``
-
-### Append the following to the GRUB_CMDLINE_LINUX_DEFAULT="quiet splash section.
-``
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash module_blacklist=hid_sensor_hub"
-``
-
-### Then run
-``sudo update-grub``
+### Disable the Ambient Light Sensor so that your brightness keys work, 13th gen only.
+``echo "blacklist hid_sensor_hub" | sudo tee -a /etc/modprobe.d/blacklist-light-sensor.conf``
 
 ### Workaround needed to get the best suspend battery life for SSD power drain.
 ``sudo gnome-text-editor /etc/default/grub``


### PR DESCRIPTION
Use a separate file to disable the Ambient Light Sensor (ALS) by blacklisting the `hid_sensor_hub` module.

This is safer and simpler than editing the grub default file.

It also separates this from the mechanism to notify users of an updated OEM kernel.

Currently testing on Framework 13, 13th Gen Intel using Ubuntu 22.04.3 LTS.
