### PR TITLE
OEM-C kernel update: leave parameters alone

### DIFF
--- a/22.04-OEM-C.md
+++ b/22.04-OEM-C.md
@@ -10,6 +10,5 @@
 ```
 latest_oem_kernel=$(ls /boot/vmlinuz-* | awk -F"-" '{split($0, a, "-"); version=a[3]; if (version>max) {max=version; kernel=a[2] "-" a[3] "-" a[4]}} END{print kernel}')
 sudo sed -i.bak '/^GRUB_DEFAULT=/c\GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux '"$latest_oem_kernel"'"' /etc/default/grub
-sudo sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT.*/GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"/g' /etc/default/grub
 sudo update-grub
 ```


### PR DESCRIPTION
[Fixes #20]

This page is referred to by a start up check for out of date kernel image in the grub config as created using various Ubuntu 22.04 pages.

The kernel parameters may be set differently for different generations of framework laptop, and only need to be set once.

Leave this line (`GRUB_CMDLINE_LINUX_DEFAULT`) alone on updates to the kernel to avoid clobbering the changes made for the particular generation of framework laptop.
