### PR TITLE
Fix typo which breaks Fedora-easy-effects-13-installer.sh

### DIFF
--- a/easy-effects/Fedora-easy-effects-13-installer.sh
+++ b/easy-effects/Fedora-easy-effects-13-installer.sh
@@ -37,7 +37,7 @@ clear
 # Define config directory and file
 config_dir=~/.var/app/com.github.wwmm.easyeffects/config/easyeffects/output
 config_file="$config_dir/fw13-easy-effects.json"
-irs_dir=/.var/app/com.github.wwmm.easyeffects/config/easyeffects/irs
+irs_dir=~/.var/app/com.github.wwmm.easyeffects/config/easyeffects/irs
 irs_file="$irs_dir/IR_22ms_27dB_5t_15s_0c.irs"
 
 # Create config directory if it doesn't exist


### PR DESCRIPTION
Fixed a typo which prevents Fedora-easy-effects-13-installer.sh from downloading the convolver impact file due to nonexistent directory.

I ran into this today, where attempting to run the script as per the docs kept throwing:
```
Error: The downloaded convolver impact file is empty. Please check the source URL.
```
Then saw in the code `.var` was being referenced without a `~` to the user's home directory. After adding that back into the file it worked as expected.