### PR TITLE
Update buzzing sound fix

### DIFF
--- a/framework13/Fedora41-amd-fw13.md
+++ b/framework13/Fedora41-amd-fw13.md
@@ -32,6 +32,7 @@ sudo dnf upgrade
 
 ### Step 2 - If you want to enable fractional scaling on Wayland:
 
+- Browse to the horizontal line in the upper left corner, click to open it.
 - Type out the word Displays.
 - Look for scale you want and select it, click Apply.
 

--- a/framework13/Fedora41-amd-fw13.md
+++ b/framework13/Fedora41-amd-fw13.md
@@ -84,7 +84,8 @@ echo 0 | sudo tee /sys/module/snd_hda_intel/parameters/power_save
 ```
 
 ```
-# Persistent fix to disable power save using Tuned
+# Persistent fix to disable power save using Tuned (either change the power profile or reboot to apply)
+# Note: Change "balanced" to the profile you want this set on
 sudo mkdir -p /etc/tuned/profiles/balanced/
 sudo cp /usr/lib/tuned/profiles/balanced/tuned.conf /etc/tuned/profiles/balanced/
 sudo sed -i 's/timeout=10/timeout=0/g' /etc/tuned/profiles/balanced/tuned.conf

--- a/framework13/Fedora41-amd-fw13.md
+++ b/framework13/Fedora41-amd-fw13.md
@@ -75,16 +75,23 @@ sudo grubby --update-kernel=ALL --args="amdgpu.sg_display=0"
 
 - Browse to the horizontal line in the upper left corner, click to open it.
 - Type out the word terminal, click to open it.
-- Copy/paste in the following code below.
-- Press the enter key, user password, enter key.
+- Copy/paste in the code below (use either the immediate temporary fix or persistent fix).
+- Then press the enter key, user password, enter key.
 
 ```
+# Immediate temporary fix to disable power save for running session (no reboot required)
 echo 0 | sudo tee /sys/module/snd_hda_intel/parameters/power_save
 ```
+
+```
+# Persistent fix to disable power save using Tuned
+sudo mkdir -p /etc/tuned/profiles/balanced/
+sudo cp /usr/lib/tuned/profiles/balanced/tuned.conf /etc/tuned/profiles/balanced/
+sudo sed -i 's/timeout=10/timeout=0/g' /etc/tuned/profiles/balanced/tuned.conf
+```
+
 > **TIP:** You can use the little clipboard icon to the right of the code to copy to your clipboard.
 
-
-**Reboot**
 
 &nbsp;
 &nbsp;


### PR DESCRIPTION
PR updates workaround for "Buzzing sound from 3.5mm jack" to include both a temporary and persistent fix (using tuned). 

Also adds a minor addition to step 2 for uniformity. 