### PR TITLE
Update fw13-easy-effects.json for new Convolver declaration

### DIFF
--- a/easy-effects/fw13-easy-effects.json
+++ b/easy-effects/fw13-easy-effects.json
@@ -17,7 +17,7 @@
             "bypass": false,
             "input-gain": 0.0,
             "ir-width": 100,
-            "kernel-path": "%CFG%/irs/IR_22ms_27dB_5t_15s_0c.irs",
+            "kernel-name": "IR_22ms_27dB_5t_15s_0c",
             "output-gain": 6.0
         },
         "filter#0": {


### PR DESCRIPTION
As of EasyEffects 7.1.7, 'kernel-path' is depreciated and now uses 'kernel-name'

See the second bullet under 7.1.7's "Other notes" in the changelog:
https://github.com/wwmm/easyeffects/blob/master/CHANGELOG.md#717