### PR TITLE
Fix ubuntu version number typo in FW12 accelerometer bug guide

### DIFF
--- a/framework12/Ubuntu-25-04-accel-ubuntu25.04.md
+++ b/framework12/Ubuntu-25-04-accel-ubuntu25.04.md
@@ -4,7 +4,7 @@ This guide will help set up screen rotation support for your laptop on Ubuntu 25
 
 > Rather not deal with this at all? [Bazzite](https://guides.frame.work/Guide/Bazzite+Installation+on+the+Framework+Laptop+12/409?lang=en) and [Fedora](https://guides.frame.work/Guide/Fedora+42+Installation+on+the+Framework+Laptop+12/410?lang=en) are ready to go out of the box, zero configuration.
 
-Ubuntu 25.05 currently ships with iio-sensor-proxy 3.7 that has [a bug](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/issues/411) preventing it from delivering accelerometer events from kernel to userspace (GNOME, KDE, ...).
+Ubuntu 25.04 currently ships with iio-sensor-proxy 3.7 that has [a bug](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/issues/411) preventing it from delivering accelerometer events from kernel to userspace (GNOME, KDE, ...).
 
 ```
 sed 's/.*iio-buffer-accel/#&/' /usr/lib/udev/rules.d/80-iio-sensor-proxy.rules | sudo tee /etc/udev/rules.d/80-iio-sensor-proxy.rules


### PR DESCRIPTION
When I first read this I thought it was talking about two separate issues in two different versions of Ubuntu, but of course there is no version 25.05