### PR TITLE
Fix: Enable Tablet Mode Auto-Rotation on Arch Linux

### DIFF
--- a/framework12/Arch-accel.md
+++ b/framework12/Arch-accel.md
@@ -1,0 +1,48 @@
+# Arch Linux Tablet Mode Setup
+
+This guide will help you enable automatic screen rotation on Arch Linux and its derivatives. On many systems, the required package is not installed by default, and the available version may require a workaround to function correctly.
+
+> Rather not deal with this at all? [Bazzite](https://guides.frame.work/Guide/Bazzite+Installation+on+the+Framework+Laptop+12/409?lang=en) and [Fedora](https://guides.frame.work/Guide/Fedora+42+Installation+on+the+Framework+Laptop+12/410?lang=en) have this working out of the box, with zero configuration required.
+
+On a standard Arch Linux installation, the `iio-sensor-proxy` package that manages accelerometer data is not installed. Furthermore, some repositories may provide version 3.7, which has [a bug](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/issues/411) preventing it from delivering sensor events to your desktop environment (GNOME, KDE, etc.).
+
+The following steps will guide you through installing the package and applying the necessary fix.
+
+### Step 1: Install `iio-sensor-proxy`
+
+First, open a terminal and install the package using `pacman`.
+
+```bash
+sudo pacman -S iio-sensor-proxy
+````
+
+### Step 2: Apply the udev Workaround
+
+Next, apply the one-line command to fix the bug. This command comments out the problematic rule and reloads the system services.
+
+```bash
+sed 's/.*iio-buffer-accel/#&/' /usr/lib/udev/rules.d/80-iio-sensor-proxy.rules | sudo tee /etc/udev/rules.d/80-iio-sensor-proxy.rules
+sudo udevadm trigger --settle
+sudo systemctl restart iio-sensor-proxy
+```
+
+### Step 3: Verify the Fix
+
+Finally, you can check if screen rotation is working correctly.
+
+```bash
+monitor-sensor --accel
+```
+
+You should see the following output, confirming the accelerometer is detected:
+
+```
+    Waiting for iio-sensor-proxy to appear
++++ iio-sensor-proxy appeared
+=== Has accelerometer (orientation: normal)
+```
+
+> Tablet rotation mode should now work immediately. However, if for some reason it does not, reboot your computer and then test rotation again. Remember to flip the screen completely back to test rotation properly.
+
+```
+```


### PR DESCRIPTION
Of course. Here is a pull request description based on the guide you created. You can use this as a template for submitting your changes.

---
## **Fix: Enable Tablet Mode Auto-Rotation on Arch Linux**

### **Problem**

Automatic screen rotation does not work out of the box on many Arch Linux installations (and its derivatives) for two primary reasons:

1.  The `iio-sensor-proxy` package, which is required to read accelerometer data, is not installed by default.
2.  The version of `iio-sensor-proxy` available in some repositories (version 3.7) has a known [[upstream bug](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/issues/411)](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/issues/411) that prevents it from correctly processing sensor data due to a faulty `udev` rule.

This leaves users without a functional tablet mode experience.

### **Solution**

This PR adds a new guide that provides a clear, step-by-step solution for Arch Linux users to enable automatic screen rotation. The guide instructs users to:

1.  **Install the necessary package:** `sudo pacman -S iio-sensor-proxy`
2.  **Apply a udev workaround:** A `sed` command is used to comment out the problematic `iio-buffer-accel` line in the `udev` rules, forcing the system to use a working method to poll the sensor.
3.  **Restart the relevant services** to apply the changes immediately.

This approach resolves the issue completely and restores the expected auto-rotation functionality.

### **How to Test**

1.  Follow the steps outlined in the new "Arch Linux Tablet Mode Setup" guide.
2.  Run `monitor-sensor --accel` after completing the steps.
3.  Confirm that the output includes the line `=== Has accelerometer (orientation: normal)`.
4.  Physically rotate the device to confirm the screen orientation changes accordingly.