### PR TITLE
framework12 iio-sensor-proxy 3.8 has been released

### DIFF
--- a/framework12/Ubuntu-25-04-accel-ubuntu25.04.md
+++ b/framework12/Ubuntu-25-04-accel-ubuntu25.04.md
@@ -6,8 +6,8 @@ This guide will help set up screen rotation support for your laptop on Ubuntu 25
 
 Ubuntu 25.04 currently ships with iio-sensor-proxy 3.7 that has [a bug](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/issues/411) preventing it from delivering accelerometer events from kernel to userspace (GNOME, KDE, ...).
 
-We have [submitted a bug](https://bugs.launchpad.net/ubuntu/+source/iio-sensor-proxy/+bug/2117530) to backport the upstream fix.
-In the meanwhile you can use the following workaround.
+We have [submitted a bug](https://bugs.launchpad.net/ubuntu/+source/iio-sensor-proxy/+bug/2117530) to backport the upstream fix or update to 3.8.
+In the meanwhile you can use the following workaround:
 
 ```
 sed 's/.*iio-buffer-accel/#&/' /usr/lib/udev/rules.d/80-iio-sensor-proxy.rules | sudo tee /etc/udev/rules.d/80-iio-sensor-proxy.rules

--- a/framework12/debugging.md
+++ b/framework12/debugging.md
@@ -122,10 +122,11 @@ If no, make sure the package is installed and the service is enabled and running
 	Accelerometer orientation changed: normal
 ```
 
-If not, you are likely running iio-sensor-proxy 3.7.
-A fix has been [merged upstream](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/merge_requests/400).
-Until the next release has reached distributions, you can either downgrade to
-3.7 or remove a line in the udev config:
+If not, you are likely running iio-sensor-proxy 3.7, which has a
+[known regression](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/merge_requests/400)
+that is fixed in iio-sensor-proxy 3.8.
+If your distribution has not updated to 3.8, you can either downgrade to
+3.6 or remove a line in the udev config:
 
 ```
 sed 's/.*iio-buffer-accel/#&/' /usr/lib/udev/rules.d/80-iio-sensor-proxy.rules | sudo tee /etc/udev/rules.d/80-iio-sensor-proxy.rules


### PR DESCRIPTION
NixOS and Fedora have updated already.
Arch is in progress.
Ubuntu has not.