### PR TITLE
Create Ubuntu-25-10.md

### DIFF
--- a/framework12/Ubuntu-25-10.md
+++ b/framework12/Ubuntu-25-10.md
@@ -1,0 +1,10 @@
+# Enabling tablet mode in Ubuntu 25.10
+
+For tablet mode to work, the kernel modules `pinctrl_tigerlake` and `soc_button_array` must be loaded in order. Ubuntu 25.10 may load `soc_button_array` first which prevents tablet mode from working. 
+
+To fix this run:
+```
+echo "force_drivers+=" pinctrl_tigerlake "" | sudo tee /etc/dracut.conf.d/fw12_tablet_mode_fix.conf
+sudo update-initramfs -u
+```
+This makes sure the `pinctrl_tigerlake` module is loaded first by adding it to the initramfs.


### PR DESCRIPTION
Tablet mode might not work on some Ubuntu 25.10 installations due to `pinctrl_tigerlake` not being loaded first. This outlines the necessary fix.

See here for people having this issue:
- https://community.frame.work/t/ubuntu-25-10-screen-rotation-not-working/75999