### PR TITLE
Update NixOS accelerometer info

### DIFF
--- a/framework12/nixOS.md
+++ b/framework12/nixOS.md
@@ -17,7 +17,7 @@ sure it's loaded first by loading it from the initrd.
 You can either use the nixos-hardware configuration mentioned above, or
 configure it manually:
 
-```
+```nix
 boot.initrd.kernelModules = [ "pinctrl_tigerlake" ];
 ```
 
@@ -26,13 +26,18 @@ boot.initrd.kernelModules = [ "pinctrl_tigerlake" ];
 iio-sensor-proxy reads the accelerometer data from the kernel and passes it to the desktop environment via dbus.
 
 Version 3.7 has a bug, making it incompatible with Framework 12.
-NixOS 25.05 and NixOS 25.11 (unstable) are patched:
+NixOS channels 25.05 and newer are patched:
 
 - https://github.com/NixOS/nixpkgs/pull/427476
 - https://github.com/NixOS/nixpkgs/pull/427853
 
+To enable the accelerometer:
 
-If you haven't got the patched version yet, you can apply the following workaround:
+```nix
+hardware.sensor.iio.enable = true;
+```
+
+If you're using an outdated NixOS version, you can apply the following workaround:
 
 ```nix
 nixpkgs.overlays = [
@@ -44,4 +49,17 @@ nixpkgs.overlays = [
     });
   })
 ];
+```
+
+## Disabling the touchscreen
+
+It is possible to entirely disable the touchscreen while maintaining stylus functionality.
+This can be done with an udev rule:
+
+```nix
+services.libinput.enable = true; # If not already present
+
+services.udev.extraRules = ''
+  ACTION=="add|change", ENV{ID_INPUT_TOUCHSCREEN}=="1", ENV{LIBINPUT_IGNORE_DEVICE}="1"
+'';
 ```

--- a/framework12/nixOS.md
+++ b/framework12/nixOS.md
@@ -63,3 +63,5 @@ services.udev.extraRules = ''
   ACTION=="add|change", ENV{ID_INPUT_TOUCHSCREEN}=="1", ENV{LIBINPUT_IGNORE_DEVICE}="1"
 '';
 ```
+
+This breaks auto-rotate using iio. A work-around for Gnome is to use `gnomeExtensions.screen-rotate`


### PR DESCRIPTION
I found out I needed to add `hardware.sensor.iio.enable = true;` in order to have automatic screen rotation, which I didn't find documented anywhere, so I figured it would be handy to include here.

Also includes a way to disable the touchscreen. Many Framework Laptop 12 owners have previously complained about the quality of the palm rejection. I was having trouble with palm rejection while drawing, so I figured out how to disable the touchscreen entirely while keeping stylus functionality. It might come in handy for someone.